### PR TITLE
Update nzbhydra.yml

### DIFF
--- a/mods/containers/primary/.pendingremake/nzbhydra.yml
+++ b/mods/containers/primary/.pendingremake/nzbhydra.yml
@@ -15,7 +15,7 @@
         pgrole: 'nzbhydra'
         intport: '5076'
         extport: '5076'
-        image: 'linuxserver/hydra2'
+        image: 'linuxserver/nzbhydra2'
 
     # CORE (MANDATORY) ############################################################
     - name: 'Including cron job'


### PR DESCRIPTION
Linuxserver deprecated the former image so it will no longer receive updates:

Per https://hub.docker.com/r/linuxserver/hydra2:
"THIS IMAGE IS DEPRECATED. We will continue releases with a new image under the correct name: linuxserver/nzbhydra2."

Was perusing code and noticed it still had the old image in this branch, figured i'd pr in the mean time to ensure it isn't missed during remake.