### PR TITLE
Fix docker rm on traefik destroy

### DIFF
--- a/mods/functions/traefik_menu_start
+++ b/mods/functions/traefik_menu_start
@@ -40,8 +40,8 @@ case $typed in
     9 ) menutmp=4 && traefik_keys && traefik_menu_start && exit ;;
     A ) traefik_deploy && traefik_menu_start && exit ;;
     a ) traefik_deploy && traefik_menu_start && exit ;;
-    B ) docker stop traefik >/dev/null 2>&1 && docker rm && docker rm $1 >/dev/null 2>&1 && traefik_menu_start && exit ;;
-    b ) docker stop traefik >/dev/null 2>&1 && docker rm && docker rm $1 >/dev/null 2>&1 && traefik_menu_start && exit ;;
+    B ) docker stop traefik >/dev/null 2>&1 && docker rm traefik >/dev/null 2>&1 && traefik_menu_start && exit ;;
+    b ) docker stop traefik >/dev/null 2>&1 && docker rm traefik >/dev/null 2>&1 && traefik_menu_start && exit ;;
     z ) start_menu && exit ;;
     Z ) start_menu && exit ;;
     * ) traefik_menu_start && exit ;;


### PR DESCRIPTION
currently the "Destroy traefik" option throws an error and exits the script, this PR fixes it